### PR TITLE
sched: disable gfsleepers for ui performance

### DIFF
--- a/kernel/sched_features.h
+++ b/kernel/sched_features.h
@@ -3,7 +3,7 @@
  * them to run sooner, but does not allow tons of sleepers to
  * rip the spread apart.
  */
-SCHED_FEAT(GENTLE_FAIR_SLEEPERS, 1)
+SCHED_FEAT(GENTLE_FAIR_SLEEPERS, 0)
 
 /*
  * Place new tasks ahead so that they do not starve already running


### PR DESCRIPTION
Disable gentle fair sleepers provide a better ui performance
